### PR TITLE
Logs impl

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,10 @@ services:
       - "8761:8761"
     environment:
       - JAVA_OPTS=-Xmx512m
+      - SPRING_RABBITMQ_HOST=${RABBITMQ_HOST}
+      - SPRING_RABBITMQ_PORT=5672
+      - SPRING_RABBITMQ_USERNAME=${RABBITMQ_USERNAME}
+      - SPRING_RABBITMQ_PASSWORD=${RABBITMQ_PASSWORD}
     networks:
       - shared_network
 networks:

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,10 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-amqp</artifactId>
+		</dependency>
 	</dependencies>
 	<dependencyManagement>
 		<dependencies>

--- a/src/main/java/com/gtu/discovery_service/DiscoveryServiceApplication.java
+++ b/src/main/java/com/gtu/discovery_service/DiscoveryServiceApplication.java
@@ -1,8 +1,14 @@
 package com.gtu.discovery_service;
 
+import java.time.Instant;
+import java.util.Map;
+
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.cloud.netflix.eureka.server.EnableEurekaServer;
+import org.springframework.context.event.EventListener;
 
 @SpringBootApplication
 @EnableEurekaServer
@@ -11,5 +17,19 @@ public class DiscoveryServiceApplication {
 	public static void main(String[] args) {
 		SpringApplication.run(DiscoveryServiceApplication.class, args);
 	}
+
+	@Autowired
+    private LogPublisher logPublisher;
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void onApplicationReady() {
+        logPublisher.sendLog(
+            Instant.now().toString(),
+            "discovery-service",
+            "INFO",
+            "Discovery Service is up and running",
+            Map.of()
+        );
+    }
 
 }

--- a/src/main/java/com/gtu/discovery_service/EurekaEventsListener.java
+++ b/src/main/java/com/gtu/discovery_service/EurekaEventsListener.java
@@ -1,0 +1,60 @@
+package com.gtu.discovery_service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.netflix.eureka.server.event.EurekaInstanceCanceledEvent;
+import org.springframework.cloud.netflix.eureka.server.event.EurekaInstanceRegisteredEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Component
+public class EurekaEventsListener {
+
+
+
+    @Autowired
+    private LogPublisher logPublisher;
+
+    private final Set<String> canceledInstances = ConcurrentHashMap.newKeySet();
+
+    @EventListener
+    public void onInstanceRegistered(EurekaInstanceRegisteredEvent event) {
+        if (!event.isReplication() && event.getInstanceInfo().getStatus().toString().equals("UP")) {
+        
+            logPublisher.sendLog(
+                Instant.now().toString(),
+                "discovery-service",
+                "INFO",
+                "✅ New service registered: " + event.getInstanceInfo().getInstanceId(),
+                Map.of(
+                    "instanceId", event.getInstanceInfo().getInstanceId(),
+                    "ipAddr", event.getInstanceInfo().getIPAddr(),
+                    "status", event.getInstanceInfo().getStatus().toString()
+                )
+            );
+        }
+    }
+
+    @EventListener
+    public void onInstanceCanceled(EurekaInstanceCanceledEvent event) {
+        if (!event.isReplication()) {
+            if (canceledInstances.add(event.getServerId())) {   
+                logPublisher.sendLog(
+                    Instant.now().toString(),
+                    "discovery-service",
+                    "WARN",
+                    "❌ Service disconnected: " + event.getServerId(),
+                    Map.of(
+                        "serverId", event.getServerId()
+                    )
+                );
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/gtu/discovery_service/LogPublisher.java
+++ b/src/main/java/com/gtu/discovery_service/LogPublisher.java
@@ -1,0 +1,53 @@
+package com.gtu.discovery_service;
+
+import org.slf4j.LoggerFactory;
+import org.springframework.amqp.core.AmqpTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.beans.factory.annotation.Value;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.slf4j.Logger;
+
+import java.util.Map;
+@Component
+public class LogPublisher {
+
+    private final AmqpTemplate amqpTemplate;
+
+    @Value("${rabbitmq.exchange.log}")
+    private String exchange;
+
+    @Value("${rabbitmq.routingkey.log}")
+    private String routingKey;
+
+    private final ObjectMapper objectMapper;
+
+    private static final Logger logger = LoggerFactory.getLogger(LogPublisher.class);
+
+    public LogPublisher(AmqpTemplate amqpTemplate) {
+        this.amqpTemplate = amqpTemplate;
+        this.objectMapper = new ObjectMapper();
+    }
+
+    public void sendLog(String timestamp, String service, String level, String message, Map<String, Object> details) {
+        try {
+            
+            Map<String, Object> log = Map.of(
+            "timestamp", timestamp,
+            "service", service,
+            "level", level,
+            "message", message,
+            "details", details
+            );
+
+            String logJson = objectMapper.writeValueAsString(log);
+       
+            amqpTemplate.convertAndSend(exchange, routingKey, logJson);
+
+        } catch (Exception e) {
+            logger.error("Failed to send log message", e);    
+        }
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,3 +2,6 @@ spring.application.name=discovery-service
 server.port=8761
 eureka.client.register-with-eureka=false
 eureka.client.fetch-registry=false
+
+rabbitmq.exchange.log=log-exchange
+rabbitmq.routingkey.log=log-routing-key

--- a/src/test/java/com/gtu/discovery_service/EurekaEventsListenerTest.java
+++ b/src/test/java/com/gtu/discovery_service/EurekaEventsListenerTest.java
@@ -19,7 +19,7 @@ class EurekaEventsListenerTest {
     void setUp() {
         logPublisher = mock(LogPublisher.class);
         listener = new EurekaEventsListener();
-        // Inyectar el mock usando reflexión (ya que el campo es privado y @Autowired)
+        // Inject the mock using reflection (since the field is private and annotated with @Autowired)
         java.lang.reflect.Field field;
         try {
             field = EurekaEventsListener.class.getDeclaredField("logPublisher");

--- a/src/test/java/com/gtu/discovery_service/EurekaEventsListenerTest.java
+++ b/src/test/java/com/gtu/discovery_service/EurekaEventsListenerTest.java
@@ -1,0 +1,98 @@
+package com.gtu.discovery_service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.cloud.netflix.eureka.server.event.EurekaInstanceCanceledEvent;
+import org.springframework.cloud.netflix.eureka.server.event.EurekaInstanceRegisteredEvent;
+import com.netflix.appinfo.InstanceInfo;
+
+import java.util.Map;
+
+import static org.mockito.Mockito.*;
+
+class EurekaEventsListenerTest {
+
+    private LogPublisher logPublisher;
+    private EurekaEventsListener listener;
+
+    @BeforeEach
+    void setUp() {
+        logPublisher = mock(LogPublisher.class);
+        listener = new EurekaEventsListener();
+        // Inyectar el mock usando reflexión (ya que el campo es privado y @Autowired)
+        java.lang.reflect.Field field;
+        try {
+            field = EurekaEventsListener.class.getDeclaredField("logPublisher");
+            field.setAccessible(true);
+            field.set(listener, logPublisher);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    void onInstanceRegistered_shouldLogWhenUpAndNotReplication() {
+        InstanceInfo instanceInfo = mock(InstanceInfo.class);
+        when(instanceInfo.getStatus()).thenReturn(InstanceInfo.InstanceStatus.UP);
+        when(instanceInfo.getInstanceId()).thenReturn("test-instance");
+        when(instanceInfo.getIPAddr()).thenReturn("127.0.0.1");
+
+        EurekaInstanceRegisteredEvent event = mock(EurekaInstanceRegisteredEvent.class);
+        when(event.isReplication()).thenReturn(false);
+        when(event.getInstanceInfo()).thenReturn(instanceInfo);
+
+        listener.onInstanceRegistered(event);
+
+        verify(logPublisher, times(1)).sendLog(
+                anyString(),
+                eq("discovery-service"),
+                eq("INFO"),
+                contains("test-instance"),
+                argThat((Map<String, Object> map) ->
+                        "test-instance".equals(map.get("instanceId")) &&
+                        "127.0.0.1".equals(map.get("ipAddr")) &&
+                        "UP".equals(map.get("status"))
+                )
+        );
+    }
+
+    @Test
+    void onInstanceRegistered_shouldNotLogWhenReplication() {
+        EurekaInstanceRegisteredEvent event = mock(EurekaInstanceRegisteredEvent.class);
+        when(event.isReplication()).thenReturn(true);
+
+        listener.onInstanceRegistered(event);
+
+        verify(logPublisher, never()).sendLog(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    void onInstanceCanceled_shouldLogOncePerServerId() {
+        EurekaInstanceCanceledEvent event = mock(EurekaInstanceCanceledEvent.class);
+        when(event.isReplication()).thenReturn(false);
+        when(event.getServerId()).thenReturn("server-1");
+
+        listener.onInstanceCanceled(event);
+        listener.onInstanceCanceled(event); // Debe loguear solo la primera vez
+
+        verify(logPublisher, times(1)).sendLog(
+                anyString(),
+                eq("discovery-service"),
+                eq("WARN"),
+                contains("server-1"),
+                argThat((Map<String, Object> map) ->
+                        "server-1".equals(map.get("serverId"))
+                )
+        );
+    }
+
+    @Test
+    void onInstanceCanceled_shouldNotLogWhenReplication() {
+        EurekaInstanceCanceledEvent event = mock(EurekaInstanceCanceledEvent.class);
+        when(event.isReplication()).thenReturn(true);
+
+        listener.onInstanceCanceled(event);
+
+        verify(logPublisher, never()).sendLog(any(), any(), any(), any(), any());
+    }
+}

--- a/src/test/java/com/gtu/discovery_service/LogPublisherTest.java
+++ b/src/test/java/com/gtu/discovery_service/LogPublisherTest.java
@@ -1,0 +1,63 @@
+package com.gtu.discovery_service;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.amqp.core.AmqpTemplate;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+class LogPublisherTest {
+
+    @Mock
+    private AmqpTemplate amqpTemplate;
+
+    @InjectMocks
+    private LogPublisher logPublisher;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        MockitoAnnotations.openMocks(this);
+
+        setPrivateField(logPublisher, "exchange", "test.exchange");
+        setPrivateField(logPublisher, "routingKey", "test.routingkey");
+    }
+
+    private void setPrivateField(Object target, String fieldName, Object value) throws Exception {
+        Field field = target.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(target, value);
+    }
+
+    @Test
+    void sendLog_ShouldSendMessageSuccessfully() throws Exception {
+        Map<String, Object> details = new HashMap<>();
+        details.put("key", "value");
+
+        logPublisher.sendLog("2023-01-01T12:00:00Z", "auth-service", "INFO", "Test log", details);
+
+        verify(amqpTemplate, times(1))
+                .convertAndSend(eq("test.exchange"), eq("test.routingkey"), anyString());
+
+        verifyNoMoreInteractions(amqpTemplate);
+    }
+
+    @Test
+    void sendLog_ShouldHandleExceptionGracefully() throws Exception {
+        Map<String, Object> details = new HashMap<>();
+        doThrow(new RuntimeException("AMQP error")).when(amqpTemplate).convertAndSend(anyString(), anyString(), anyString());
+
+        logPublisher.sendLog("2023-01-01T12:00:00Z", "auth-service", "ERROR", "Test error", details);
+
+        verify(amqpTemplate, times(1))
+                .convertAndSend(anyString(), anyString(), anyString());
+    }
+}


### PR DESCRIPTION
This pull request introduces RabbitMQ integration for enhanced logging in the Discovery Service. It includes changes to configure RabbitMQ, implement a logging mechanism, and add event listeners for monitoring Eureka service events. Unit tests have also been added to ensure the correctness of the new functionality.

### RabbitMQ Configuration:
* Added RabbitMQ environment variables (`SPRING_RABBITMQ_HOST`, `SPRING_RABBITMQ_PORT`, `SPRING_RABBITMQ_USERNAME`, `SPRING_RABBITMQ_PASSWORD`) to `docker-compose.yml` for RabbitMQ connectivity.
* Added RabbitMQ exchange and routing key configuration (`rabbitmq.exchange.log`, `rabbitmq.routingkey.log`) to `application.properties`.
* Included the `spring-boot-starter-amqp` dependency in `pom.xml` to enable RabbitMQ support.

### Logging Mechanism:
* Created a `LogPublisher` component to send logs to RabbitMQ, including details such as timestamp, service name, log level, message, and additional metadata.

### Eureka Event Listeners:
* Added an `EurekaEventsListener` class to handle `EurekaInstanceRegisteredEvent` and `EurekaInstanceCanceledEvent`. Logs are published to RabbitMQ when services are registered or disconnected. Duplicate cancellation logs are prevented using a `ConcurrentHashMap`.
* Enhanced the `DiscoveryServiceApplication` class to log a message when the application is ready.

### Unit Testing:
* Added `EurekaEventsListenerTest` to verify logging behavior for service registration and cancellation events, including edge cases like replication events.
* Added `LogPublisherTest` to validate RabbitMQ message publishing and error handling in the `LogPublisher` component.